### PR TITLE
Fixed curl POSTFIELDS (request body) setter with array parameter

### DIFF
--- a/src/Unirest/Request.php
+++ b/src/Unirest/Request.php
@@ -405,6 +405,10 @@ class Request
 				curl_setopt(self::$handle, CURLOPT_CUSTOMREQUEST, $method);
 			}
 
+            if (is_array($body)) {
+                $body = http_build_query($body);
+            }
+            
             curl_setopt(self::$handle, CURLOPT_POSTFIELDS, $body);
         } elseif (is_array($body)) {
             if (strpos($url, '?') !== false) {


### PR DESCRIPTION
…ray in values

Fixed "Array to string conversion" error when you need POST an array parameter. For example:
[
'foo' => 'bar',
'ids' => [
        0 => 1000,
        1 => 1001,
        2 => 1002
    ]
]